### PR TITLE
Add CellPointerPressed event + Make avalonia reference nightly-invariant

### DIFF
--- a/src/Avalonia.DataGrid.Themes.Default/Avalonia.DataGrid.Themes.Default.csproj
+++ b/src/Avalonia.DataGrid.Themes.Default/Avalonia.DataGrid.Themes.Default.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.6.2-build5800-beta" />
+    <PackageReference Include="Avalonia" Version="0.6.2-*" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="**\*.xaml.cs">

--- a/src/Avalonia.DataGrid/Avalonia.DataGrid.csproj
+++ b/src/Avalonia.DataGrid/Avalonia.DataGrid.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.6.2-build5800-beta" />
+    <PackageReference Include="Avalonia" Version="0.6.2-*" />
   </ItemGroup>
 
 </Project>

--- a/src/Avalonia.DataGrid/DataGrid.cs
+++ b/src/Avalonia.DataGrid/DataGrid.cs
@@ -1247,6 +1247,11 @@ namespace Avalonia.Controls
         public event EventHandler<DataGridCellEditEndingEventArgs> CellEditEnding;
 
         /// <summary>
+        /// Occurs when cell is mouse-pressed.
+        /// </summary>
+        public event EventHandler<DataGridCellPointerPressedEventArgs> CellPointerPressed;
+
+        /// <summary>
         /// Occurs when the <see cref="P:Avalonia.Controls.DataGridColumn.DisplayIndex" /> 
         /// property of a column changes.
         /// </summary>
@@ -2221,6 +2226,14 @@ namespace Avalonia.Controls
         protected virtual void OnCellEditEnding(DataGridCellEditEndingEventArgs e)
         {
             CellEditEnding?.Invoke(this, e);
+        }
+
+        /// <summary>
+        /// Raises the CellPointerPressed event.
+        /// </summary>
+        internal virtual void OnCellPointerPressed(DataGridCellPointerPressedEventArgs e)
+        {
+            CellPointerPressed?.Invoke(this, e);
         }
         
         /// <summary>

--- a/src/Avalonia.DataGrid/DataGridCell.cs
+++ b/src/Avalonia.DataGrid/DataGridCell.cs
@@ -86,7 +86,7 @@ namespace Avalonia.Controls
                        OwningGrid.CurrentSlot == OwningRow.Slot;
             }
         }
-        
+
         private bool IsEdited
         {
             get
@@ -95,7 +95,7 @@ namespace Avalonia.Controls
                        OwningGrid.EditingColumnIndex == ColumnIndex;
             }
         }
-        
+
         private bool IsMouseOver
         {
             get
@@ -127,7 +127,7 @@ namespace Avalonia.Controls
 
             UpdatePseudoClasses();
             _rightGridLine = e.NameScope.Find<Rectangle>(DATAGRIDCELL_elementRightGridLine);
-            if(_rightGridLine != null && OwningColumn == null)
+            if (_rightGridLine != null && OwningColumn == null)
             {
                 // Turn off the right GridLine for filler cells
                 _rightGridLine.IsVisible = false;
@@ -160,23 +160,22 @@ namespace Avalonia.Controls
         //TODO TabStop
         private void DataGridCell_PointerPressed(PointerPressedEventArgs e)
         {
-            if(e.MouseButton != MouseButton.Left)
-            {
-                return;
-            }
-
             // OwningGrid is null for TopLeftHeaderCell and TopRightHeaderCell because they have no OwningRow
             if (OwningGrid != null)
             {
-                if (!e.Handled)
-                //if (!e.Handled && OwningGrid.IsTabStop)
+                OwningGrid.OnCellPointerPressed(new DataGridCellPointerPressedEventArgs(this, OwningRow, OwningColumn, e));
+                if (e.MouseButton == MouseButton.Left)
                 {
-                    OwningGrid.Focus();
-                }
-                if (OwningRow != null)
-                {
-                    e.Handled = OwningGrid.UpdateStateOnMouseLeftButtonDown(e, ColumnIndex, OwningRow.Slot, !e.Handled);
-                    OwningGrid.UpdatedStateOnMouseLeftButtonDown = true;
+                    if (!e.Handled)
+                    //if (!e.Handled && OwningGrid.IsTabStop)
+                    {
+                        OwningGrid.Focus();
+                    }
+                    if (OwningRow != null)
+                    {
+                        e.Handled = OwningGrid.UpdateStateOnMouseLeftButtonDown(e, ColumnIndex, OwningRow.Slot, !e.Handled);
+                        OwningGrid.UpdatedStateOnMouseLeftButtonDown = true;
+                    }
                 }
             }
         }
@@ -262,7 +261,7 @@ namespace Avalonia.Controls
                     _rightGridLine.Fill = OwningGrid.VerticalGridLinesBrush;
                 }
 
-                bool newVisibility = 
+                bool newVisibility =
                     (OwningGrid.GridLinesVisibility == DataGridGridLinesVisibility.Vertical || OwningGrid.GridLinesVisibility == DataGridGridLinesVisibility.All)
                         && (OwningGrid.ColumnsInternal.FillerColumn.IsActive || OwningColumn != lastVisibleColumn);
 
@@ -275,7 +274,7 @@ namespace Avalonia.Controls
 
         private void OnOwningColumnSet(DataGridColumn column)
         {
-            if(column == null)
+            if (column == null)
             {
                 Classes.Clear();
             }
@@ -303,34 +302,34 @@ namespace Avalonia.Controls
     [TemplateVisualState(Name = VisualStates.StateValid, GroupName = VisualStates.GroupValidation)]
     public sealed partial class DataGridCell : ContentControl
     */
-    
 
-        //TODO Styles
-        /// <summary>
-        /// Ensures that the correct Style is applied to this object.
-        /// </summary>
-        /// <param name="previousStyle">Caller's previous associated Style</param>
-        /*internal void EnsureStyle(Style previousStyle)
+
+    //TODO Styles
+    /// <summary>
+    /// Ensures that the correct Style is applied to this object.
+    /// </summary>
+    /// <param name="previousStyle">Caller's previous associated Style</param>
+    /*internal void EnsureStyle(Style previousStyle)
+    {
+        if (Style != null
+            && (OwningColumn == null || Style != OwningColumn.CellStyle)
+            && (OwningGrid == null || Style != OwningGrid.CellStyle)
+            && (Style != previousStyle))
         {
-            if (Style != null
-                && (OwningColumn == null || Style != OwningColumn.CellStyle)
-                && (OwningGrid == null || Style != OwningGrid.CellStyle)
-                && (Style != previousStyle))
-            {
-                return;
-            }
+            return;
+        }
 
-            Style style = null;
-            if (OwningColumn != null)
-            {
-                style = OwningColumn.CellStyle;
-            }
-            if (style == null && OwningGrid != null)
-            {
-                style = OwningGrid.CellStyle;
-            }
-            SetStyleWithType(style);
-        } */
+        Style style = null;
+        if (OwningColumn != null)
+        {
+            style = OwningColumn.CellStyle;
+        }
+        if (style == null && OwningGrid != null)
+        {
+            style = OwningGrid.CellStyle;
+        }
+        SetStyleWithType(style);
+    } */
 
 
 }

--- a/src/Avalonia.DataGrid/EventArgs.cs
+++ b/src/Avalonia.DataGrid/EventArgs.cs
@@ -3,6 +3,7 @@
 // Please see http://go.microsoft.com/fwlink/?LinkID=131993 for details.
 // All other rights reserved.
 
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using System;
 using System.ComponentModel;
@@ -171,6 +172,52 @@ namespace Avalonia.Controls
         #endregion Properties
     }
     
+
+    /// <summary>
+    /// Provides information after the cell has been pressed.
+    /// </summary>
+    public class DataGridCellPointerPressedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Instantiates a new instance of this class.
+        /// </summary>
+        /// <param name="cell">The cell that has been pressed.</param>
+        /// <param name="row">The row container of the cell that has been pressed.</param>
+        /// <param name="column">The column of the cell that has been pressed.</param>
+        /// <param name="e">The pointer action that has been taken.</param>
+        public DataGridCellPointerPressedEventArgs(DataGridCell cell, 
+                                                   DataGridRow row,
+                                                   DataGridColumn column,
+                                                   PointerPressedEventArgs e)
+        {
+            Cell = cell;
+            Row = row;
+            Column = column;
+            PointerPressedEventArgs = e;
+        }
+
+        /// <summary>
+        /// The cell that has been pressed.
+        /// </summary> 
+        public DataGridCell Cell { get; }
+
+        /// <summary>
+        /// The row container of the cell that has been pressed.
+        /// </summary> 
+        public DataGridRow Row { get; }
+
+        /// <summary>
+        /// The column of the cell that has been pressed.
+        /// </summary> 
+        public DataGridColumn Column { get; }
+
+        /// <summary>
+        /// The pointer action that has been taken.
+        /// </summary> 
+        public PointerPressedEventArgs PointerPressedEventArgs { get; }
+    }
+
+
     /// <summary>
     /// Provides information just before a cell exits editing mode.
     /// </summary>


### PR DESCRIPTION
The `CellPointerPressed` event is badly needed for apps that needs to have some mouse interaction outside of what the current DataGrid provides.

The asterisk version of the PackageReference would allow the use of the DataGrid with the current/future nightly builds of Avalonia. 